### PR TITLE
商品詳細表示機能

### DIFF
--- a/app/controllers/items_controller.rb
+++ b/app/controllers/items_controller.rb
@@ -2,7 +2,7 @@ class ItemsController < ApplicationController
   before_action :authenticate_user!, except: [:index]  
 
   def index
-    @items = Item.all.order(created_at: :desc)
+    @items = Item.order(created_at: :desc)
   end
 
   def new
@@ -20,6 +20,7 @@ class ItemsController < ApplicationController
 
   def show
     @item = Item.find(params[:id])
+    
   end
 
   private

--- a/app/controllers/items_controller.rb
+++ b/app/controllers/items_controller.rb
@@ -1,5 +1,5 @@
 class ItemsController < ApplicationController
-  before_action :authenticate_user!, except: [:index]  
+  before_action :authenticate_user!, except: [:index, :show]  
 
   def index
     @items = Item.order(created_at: :desc)

--- a/app/controllers/items_controller.rb
+++ b/app/controllers/items_controller.rb
@@ -18,6 +18,10 @@ class ItemsController < ApplicationController
     end 
   end
 
+  def show
+    @item = Item.find(params[:id])
+  end
+
   private
   def item_params
     params.require(:item).permit(

--- a/app/models/category.rb
+++ b/app/models/category.rb
@@ -12,4 +12,6 @@ class Category < ActiveHash::Base
     { id: 10, name: 'ハンドメイド' },
     { id: 11, name: 'その他' }
   ]
+  include ActiveHash::Associations
+  has_many :items
 end

--- a/app/models/category.rb
+++ b/app/models/category.rb
@@ -12,7 +12,4 @@ class Category < ActiveHash::Base
     { id: 10, name: 'ハンドメイド' },
     { id: 11, name: 'その他' }
   ]
-
-  include ActiveHash::Associations
-  has_many :items
-  end
+end

--- a/app/models/condition.rb
+++ b/app/models/condition.rb
@@ -8,4 +8,6 @@ class Condition < ActiveHash::Base
     { id: 6, name: '傷や汚れあり' },
     { id: 7, name: '全体的に状態が悪い' }
   ]
+  include ActiveHash::Associations
+  has_many :items
 end

--- a/app/models/condition.rb
+++ b/app/models/condition.rb
@@ -8,7 +8,4 @@ class Condition < ActiveHash::Base
     { id: 6, name: '傷や汚れあり' },
     { id: 7, name: '全体的に状態が悪い' }
   ]
-
-  include ActiveHash::Associations
-  has_many :items
-  end
+end

--- a/app/models/delivery_area.rb
+++ b/app/models/delivery_area.rb
@@ -17,4 +17,6 @@ class DeliveryArea < ActiveHash::Base
     { id: 43, name: '長崎県' }, { id: 44, name: '熊本県' }, { id: 45, name: '大分県' },
     { id: 46, name: '宮崎県' }, { id: 47, name: '鹿児島県' }, { id: 48, name: '沖縄県' }
   ]
+  include ActiveHash::Associations
+  has_many :items
 end

--- a/app/models/delivery_area.rb
+++ b/app/models/delivery_area.rb
@@ -17,7 +17,4 @@ class DeliveryArea < ActiveHash::Base
     { id: 43, name: '長崎県' }, { id: 44, name: '熊本県' }, { id: 45, name: '大分県' },
     { id: 46, name: '宮崎県' }, { id: 47, name: '鹿児島県' }, { id: 48, name: '沖縄県' }
   ]
-
-  include ActiveHash::Associations
-  has_many :items
 end

--- a/app/models/delivery_period.rb
+++ b/app/models/delivery_period.rb
@@ -5,7 +5,4 @@ class DeliveryPeriod < ActiveHash::Base
     { id: 3, name: '2~3日で発送' },
     { id: 4, name: '4~7日で発送' }
   ]
-
-  include ActiveHash::Associations
-  has_many :items
-  end
+end

--- a/app/models/item.rb
+++ b/app/models/item.rb
@@ -2,6 +2,12 @@ class Item < ApplicationRecord
 
   belongs_to :user
   has_one_attached :image
+  extend ActiveHash::Associations::ActiveRecordExtensions
+  belongs_to_active_hash :category
+  belongs_to_active_hash :condition 
+  belongs_to_active_hash :postage
+  belongs_to_active_hash :delivery_area
+  belongs_to_active_hash :delivery_period
 
   with_options presence: true do
     validates :item_name

--- a/app/models/postage.rb
+++ b/app/models/postage.rb
@@ -4,4 +4,6 @@ class Postage < ActiveHash::Base
     { id: 2, name: '着払い（購入者負担)' },
     { id: 3, name: '送料込み（出品者負担）' }
   ]
+  include ActiveHash::Associations
+  has_many :items
 end

--- a/app/models/postage.rb
+++ b/app/models/postage.rb
@@ -4,7 +4,4 @@ class Postage < ActiveHash::Base
     { id: 2, name: '着払い（購入者負担)' },
     { id: 3, name: '送料込み（出品者負担）' }
   ]
-
-  include ActiveHash::Associations
-  has_many :items
-  end
+end

--- a/app/views/items/index.html.erb
+++ b/app/views/items/index.html.erb
@@ -129,7 +129,7 @@
     <ul class='item-lists'>
       <% @items.each do |item| %>
         <li class='list'>
-          <%= link_to "#" do %>
+          <%= link_to item_path(item.id) do %>
           <div class='item-img-content'>
             <%= image_tag item.image, class: "item-img" %>
 

--- a/app/views/items/index.html.erb
+++ b/app/views/items/index.html.erb
@@ -145,7 +145,7 @@
               <%= item.item_name %>
             </h3>
             <div class='item-price'>
-              <span><%= item.price %>円<br><%= item.postage_id %></span>
+              <span><%= item.price %>円<br><%= item.postage.name %></span>
               <div class='star-btn'>
                 <%= image_tag "star.png", class:"star-icon" %>
                 <span class='star-count'>0</span>

--- a/app/views/items/show.html.erb
+++ b/app/views/items/show.html.erb
@@ -7,7 +7,7 @@
       <%= "商品名" %>
     </h2>
     <div class="item-img-content">
-      <%= image_tag "item-sample.png" ,class:"item-box-img" %>
+      <%= image_tag @item.image ,class:"item-box-img" %>
       <%# 商品が売れている場合は、sold outを表示しましょう %>
       <div class="sold-out">
         <span>Sold Out!!</span>
@@ -16,10 +16,10 @@
     </div>
     <div class="item-price-box">
       <span class="item-price">
-        ¥ 999,999,999
+        <%= "¥#{@item.price}" %>
       </span>
       <span class="item-postage">
-        <%= "配送料負担" %>
+        <%= @item.postage.name %>
       </span>
     </div>
 

--- a/app/views/items/show.html.erb
+++ b/app/views/items/show.html.erb
@@ -27,7 +27,7 @@
         <%= link_to "商品の編集", "#", method: :get, class: "item-red-btn" %>
         <p class="or-text">or</p>
         <%= link_to "削除", "#", method: :delete, class:"item-destroy" %>
-      <% else current_user.id != @item.user_id %>
+      <% else %>
         <%= link_to "購入画面に進む", "#" ,class:"item-red-btn"%>
       <% end %>
     <% end %>

--- a/app/views/items/show.html.erb
+++ b/app/views/items/show.html.erb
@@ -4,7 +4,7 @@
 <div class="item-show">
   <div class="item-box">
     <h2 class="name">
-      <%= "商品名" %>
+      <%= @item.item_name %>
     </h2>
     <div class="item-img-content">
       <%= image_tag @item.image ,class:"item-box-img" %>
@@ -27,11 +27,11 @@
       <p class="or-text">or</p>
       <%= link_to "削除", "#", method: :delete, class:"item-destroy" %>
     <% end %>
-    <% if user_signed_in? %>
+    <% if user_signed_in? && current_user.id != @item.user_id%>
       <%= link_to "購入画面に進む", "#" ,class:"item-red-btn"%>
     <% end %>
     <div class="item-explain-box">
-      <span><%= "商品説明" %></span>
+      <span><%= @item.description %></span>
     </div>
     <table class="detail-table">
       <tbody>
@@ -96,9 +96,7 @@
       後ろの商品 ＞
     </a>
   </div>
-  <%# 詳細ページで表示されている商品のカテゴリー名を表示しましょう %>
-  <a href="#" class="another-item"><%= "商品のカテゴリー名" %>をもっと見る</a>
-  <%# //詳細ページで表示されている商品のカテゴリー名を表示しましょう %>
+  <a href="#" class="another-item"><%= @item.category.name %>をもっと見る</a>
 </div>
 
 <%= render "shared/footer" %>

--- a/app/views/items/show.html.erb
+++ b/app/views/items/show.html.erb
@@ -22,13 +22,14 @@
         <%= @item.postage.name %>
       </span>
     </div>
-    <% if user_signed_in? && current_user.id == @item.user_id %>
-      <%= link_to "商品の編集", "#", method: :get, class: "item-red-btn" %>
-      <p class="or-text">or</p>
-      <%= link_to "削除", "#", method: :delete, class:"item-destroy" %>
-    <% end %>
-    <% if user_signed_in? && current_user.id != @item.user_id%>
-      <%= link_to "購入画面に進む", "#" ,class:"item-red-btn"%>
+    <% if user_signed_in? %>
+      <% if current_user.id == @item.user_id %>
+        <%= link_to "商品の編集", "#", method: :get, class: "item-red-btn" %>
+        <p class="or-text">or</p>
+        <%= link_to "削除", "#", method: :delete, class:"item-destroy" %>
+      <% else current_user.id != @item.user_id %>
+        <%= link_to "購入画面に進む", "#" ,class:"item-red-btn"%>
+      <% end %>
     <% end %>
     <div class="item-explain-box">
       <span><%= @item.description %></span>

--- a/app/views/items/show.html.erb
+++ b/app/views/items/show.html.erb
@@ -22,20 +22,14 @@
         <%= @item.postage.name %>
       </span>
     </div>
-
-    <%# ログインしているユーザーと出品しているユーザーが、同一人物の場合と同一人物ではない場合で、処理を分けましょう %>
-
-    <%= link_to "商品の編集", "#", method: :get, class: "item-red-btn" %>
-    <p class="or-text">or</p>
-    <%= link_to "削除", "#", method: :delete, class:"item-destroy" %>
-
-    <%# 商品が売れていない場合はこちらを表示しましょう %>
-    <%= link_to "購入画面に進む", "#" ,class:"item-red-btn"%>
-    <%# //商品が売れていない場合はこちらを表示しましょう %>
-
-
-    <%# //ログインしているユーザーと出品しているユーザーが、同一人物の場合と同一人物ではない場合で、処理を分けましょう %>
-
+    <% if user_signed_in? && current_user.id == @item.user_id %>
+      <%= link_to "商品の編集", "#", method: :get, class: "item-red-btn" %>
+      <p class="or-text">or</p>
+      <%= link_to "削除", "#", method: :delete, class:"item-destroy" %>
+    <% end %>
+    <% if user_signed_in? %>
+      <%= link_to "購入画面に進む", "#" ,class:"item-red-btn"%>
+    <% end %>
     <div class="item-explain-box">
       <span><%= "商品説明" %></span>
     </div>
@@ -43,27 +37,27 @@
       <tbody>
         <tr>
           <th class="detail-item">出品者</th>
-          <td class="detail-value"><%= "出品者名" %></td>
+          <td class="detail-value"><%= @item.user.nickname %></td>
         </tr>
         <tr>
           <th class="detail-item">カテゴリー</th>
-          <td class="detail-value"><%= "カテゴリー名" %></td>
+          <td class="detail-value"><%= @item.category.name %></td>
         </tr>
         <tr>
           <th class="detail-item">商品の状態</th>
-          <td class="detail-value"><%= "商品の状態" %></td>
+          <td class="detail-value"><%= @item.condition.name %></td>
         </tr>
         <tr>
           <th class="detail-item">配送料の負担</th>
-          <td class="detail-value"><%= "発送料の負担" %></td>
+          <td class="detail-value"><%= @item.postage.name %></td>
         </tr>
         <tr>
           <th class="detail-item">発送元の地域</th>
-          <td class="detail-value"><%= "発送元の地域" %></td>
+          <td class="detail-value"><%= @item.delivery_area.name %></td>
         </tr>
         <tr>
           <th class="detail-item">発送日の目安</th>
-          <td class="detail-value"><%= "発送日の目安" %></td>
+          <td class="detail-value"><%= @item.delivery_period.name %></td>
         </tr>
       </tbody>
     </table>

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -3,5 +3,5 @@ Rails.application.routes.draw do
   devise_for :users
   root to: "items#index" 
   
-  resources :items, only: [:index, :new, :create]
+  resources :items, only: [:index, :new, :create, :show]
 end


### PR DESCRIPTION
# What
・トップページより商品詳細ページへの遷移
・商品詳細ページにて商品詳細情報を表示する
・商品詳細ページにてユーザー情報に応じて、ログイン状態に応じてボタン表示内容の変更
・Gyazoによる実装確認
　ログイン状態且つ、自身が出品した販売中商品の商品詳細ページへ遷移した動画
　：https://gyazo.com/c5e24a01be5287dc0e3e53f9e60af03c
　ログイン状態且つ、自身が出品していない販売中商品の商品詳細ページへ遷移した動画
　：https://gyazo.com/a0eefed1238d5c5f235ab46329d0eb92
　ログイン状態で、売却済み商品の商品詳細ページへ遷移した動画（現段階で商品購入機能の実装が済んでいる場合）
　：未実装のため動画なし
　ログアウト状態で、商品詳細ページへ遷移
　：https://gyazo.com/9e37f77b9c1ae02a706044c913d23503
# Why
　商品詳細情報がどのユーザーでも確認することができ、ログインユーザーは購入ページへ遷移できるようにするため